### PR TITLE
initial adding of titiler service to stack

### DIFF
--- a/deploy/stable/stack.yml
+++ b/deploy/stable/stack.yml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: '3.9'
 
 networks:
   mnemosyne_stable:
@@ -32,5 +32,32 @@ services:
     ports:
       - 7010:3000
       - 6008:3000
+    networks:
+      - mnemosyne_stable
+  titiler:
+    image: developmentseed/titiler:latest
+    deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.service == apps
+      rollback_config:
+        parallelism: 0
+      update_config:
+        parallelism: 0
+        order: stop-first
+        failure_action: rollback
+      restart_policy:
+        condition: any
+        delay: 5s
+      resources:
+        limits:
+          cpus: '1'
+          memory: 2048M
+    environment:
+      - PORT=8000
+      - WORKERS_PER_CORE=1
+    ports:
+      - 8000:8000
     networks:
       - mnemosyne_stable


### PR DESCRIPTION
Resolves #10. 

I could not get the Mnemosyne stack to deploy locally, but I did get the stack with just titiler to work. Since Mnemosyne and titiler don't communicate with each other, I figure it should work fine.

Some unknowns for me:

Do we need the resource limits?(https://github.com/GMoncrieff/mnemosyne/blob/56f5afd284dc158c8746d60bc6001cd1fa579387/deploy/stable/stack.yml#L53-L56)

What does this do? (https://github.com/GMoncrieff/mnemosyne/blob/56f5afd284dc158c8746d60bc6001cd1fa579387/deploy/stable/stack.yml#L41-L43)

The titiler and Mnemosyne services don't communicate with each other, so should we put them on separate networks? or even separate stacks? (https://github.com/GMoncrieff/mnemosyne/blob/56f5afd284dc158c8746d60bc6001cd1fa579387/deploy/stable/stack.yml#L62-L63)
